### PR TITLE
fix-getTankInfo-null

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_TFFTMultiHatch.java
+++ b/src/main/java/common/tileentities/GTMTE_TFFTMultiHatch.java
@@ -183,6 +183,8 @@ public class GTMTE_TFFTMultiHatch extends GT_MetaTileEntity_Hatch {
 
     @Override
     public FluidTankInfo[] getTankInfo(ForgeDirection from) {
+        if (mfh == null)
+            return null;
         FluidStack[] fluids = mfh.getAllFluids();
         int length = fluids.length;
         int maxCapcity = mfh.getCapacity();


### PR DESCRIPTION
fix null pointer crash on starting up server when using fluid ae to read fluids