### PR TITLE
SOFC Tweaks

### DIFF
--- a/repositories.gradle
+++ b/repositories.gradle
@@ -8,7 +8,7 @@ repositories {
     }
     maven {
         name 'ic2'
-        url 'https://maven.ic2.player.to/'
+        url 'https://maven2.ic2.player.to/'
         metadataSources {
             mavenPom()
             artifact()

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -2,25 +2,26 @@
 
 repositories {
     maven {
-        name 'GTNH Maven'
-        url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'
+        name = 'GTNH Maven'
+        url = 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'
         allowInsecureProtocol
     }
     maven {
-        name 'ic2'
-        url 'https://maven2.ic2.player.to/'
+        name = 'ic2'
+        url = 'https://maven.ic2.player.to/'
+        url ='https://maven2.ic2.player.to/'
         metadataSources {
             mavenPom()
             artifact()
         }
     }
     maven {
-        url 'https://cursemaven.com'
+        url = 'https://cursemaven.com'
         content {
             includeGroup 'curse.maven'
         }
     }
     maven {
-        url 'https://jitpack.io'
+        url = 'https://jitpack.io'
     }
 }

--- a/src/main/java/common/tileentities/GTMTE_SOFuelCellMK1.java
+++ b/src/main/java/common/tileentities/GTMTE_SOFuelCellMK1.java
@@ -33,7 +33,7 @@ import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 public class GTMTE_SOFuelCellMK1  extends GT_MetaTileEntity_EnhancedMultiBlockBase<GTMTE_SOFuelCellMK1> {
 
 	private final int OXYGEN_PER_SEC = 100;
-	private final int EU_PER_TICK = 2000;
+	private final int EU_PER_TICK = 2048;
 	private final int STEAM_PER_SEC = 20000;
 
 	public GTMTE_SOFuelCellMK1(int aID, String aName, String aNameRegional) {
@@ -146,7 +146,7 @@ public class GTMTE_SOFuelCellMK1  extends GT_MetaTileEntity_EnhancedMultiBlockBa
 					if((liquid = GT_Utility.getFluidForFilledItem(aFuel.getRepresentativeInput(0), true)) != null
 							&& hatchFluid.isFluidEqual(liquid)) {
 
-						liquid.amount = (int) Math.floor((EU_PER_TICK * 20) / aFuel.mSpecialValue);
+						liquid.amount = (EU_PER_TICK * 20) / aFuel.mSpecialValue;
 
 						if(super.depleteInput(liquid)) {
 

--- a/src/main/java/common/tileentities/GTMTE_SOFuelCellMK1.java
+++ b/src/main/java/common/tileentities/GTMTE_SOFuelCellMK1.java
@@ -32,9 +32,9 @@ import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 public class GTMTE_SOFuelCellMK1  extends GT_MetaTileEntity_EnhancedMultiBlockBase<GTMTE_SOFuelCellMK1> {
 
-	private final int OXYGEN_PER_SEC = 400;
-	private final int EU_PER_TICK = 1024;
-	private final int STEAM_PER_SEC = 18000;
+	private final int OXYGEN_PER_SEC = 100;
+	private final int EU_PER_TICK = 2000;
+	private final int STEAM_PER_SEC = 20000;
 
 	public GTMTE_SOFuelCellMK1(int aID, String aName, String aNameRegional) {
 		super(aID, aName, aNameRegional);
@@ -81,7 +81,7 @@ public class GTMTE_SOFuelCellMK1  extends GT_MetaTileEntity_EnhancedMultiBlockBa
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Gas Turbine")
             .addInfo("Oxidizes gas fuels to generate electricity without polluting the environment")
-            .addInfo("Consumes 29,480EU worth of fuel with up to 97% efficiency each second")
+            .addInfo("Consumes up to" + (EU_PER_TICK * 20) + "EU worth of fuel with up to 100% efficiency each second")
             .addInfo("Steam production requires the SOFC to heat up completely first")
             .addInfo("Outputs " + EU_PER_TICK + "EU/t and " + STEAM_PER_SEC + "L/s Steam")
             .addInfo("Additionally, requires " + OXYGEN_PER_SEC + "L/s Oxygen gas")
@@ -146,7 +146,7 @@ public class GTMTE_SOFuelCellMK1  extends GT_MetaTileEntity_EnhancedMultiBlockBa
 					if((liquid = GT_Utility.getFluidForFilledItem(aFuel.getRepresentativeInput(0), true)) != null
 							&& hatchFluid.isFluidEqual(liquid)) {
 
-						liquid.amount = Math.round((EU_PER_TICK * 20) / aFuel.mSpecialValue);
+						liquid.amount = (int) Math.floor((EU_PER_TICK * 20) / aFuel.mSpecialValue);
 
 						if(super.depleteInput(liquid)) {
 

--- a/src/main/java/common/tileentities/GTMTE_SOFuelCellMK2.java
+++ b/src/main/java/common/tileentities/GTMTE_SOFuelCellMK2.java
@@ -83,7 +83,8 @@ public class GTMTE_SOFuelCellMK2  extends GT_MetaTileEntity_EnhancedMultiBlockBa
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Gas Turbine")
             .addInfo("Oxidizes gas fuels to generate electricity without polluting the environment")
-            .addInfo("Consumes 442,200EU worth of fuel with up to 97% efficiency each second")
+            .addInfo("Consumes up to" + (EU_PER_TICK * 20) + "EU worth of fuel with up to 100% efficiency each second")
+            .addInfo("Nitrobenzene and other gas fuels above 1M EU/bucket are more efficient")
             .addInfo("Steam production requires the SOFC to heat up completely first")
             .addInfo("Outputs " + EU_PER_TICK + "EU/t and " + STEAM_PER_SEC + "L/s Steam")
             .addInfo("Additionally, requires " + OXYGEN_PER_SEC + "L/s Oxygen gas")
@@ -148,7 +149,7 @@ public class GTMTE_SOFuelCellMK2  extends GT_MetaTileEntity_EnhancedMultiBlockBa
 					if((liquid = GT_Utility.getFluidForFilledItem(aFuel.getRepresentativeInput(0), true)) != null
 							&& hatchFluid.isFluidEqual(liquid)) {
 
-						liquid.amount = Math.round((EU_PER_TICK * 20) / aFuel.mSpecialValue);
+                        liquid.amount = (int) (Math.floor((EU_PER_TICK * 20) / aFuel.mSpecialValue) / Math.max(1, aFuel.mSpecialValue / 1000));
 
 						if(super.depleteInput(liquid)) {
 


### PR DESCRIPTION
- Improved the output of the Mk I and reduced oxygen consumption to make it more viable compared to using singleblock gas turbines;
- Tweaked the fuel consumption calculation to always round down;
- Clarified the fuel consumption speed in the tooltip;
- Changed the Mk II fuel consumption to save fuel if its fuel value is above 1M per bucket (Nitrobenzene gives 125% fuel efficiency instead of 100%).

The SOFC Mk I and II are multiblock generators, for HV and IV specifically, which accept the same fuels as Gas Turbines and output EU alongside Steam/Superheated Steam, but at a lower efficiency than good turbine materials would (100% efficiency by default) and without producing any pollution.

They are an alternative way to generate power, focused on not emitting pollution, which is useful now that it's enabled again. However, the Mk I could only replace 2-3 HV Gas Turbine singleblocks and needed 400 L/s of Oxygen, which is a lot for the tier, especially for that EU/t. I buffed the numbers there, and for the Mk II I added a bit of math that reduces the fuel consumption for those that offer more than 1M EU/bucket, which currently is mainly Nitrobenzene. Using it, this multi has 125% fuel efficiency, which is closer to the 150% of other IV multis, but still below them, while again not producing any pollution.