### PR TITLE
Remove BW luvtierenhancer references

### DIFF
--- a/src/main/java/common/Recipes.java
+++ b/src/main/java/common/Recipes.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 
 import net.minecraft.item.ItemStack;
 
-import com.github.bartimaeusnek.bartworks.system.material.GT_Enhancement.LuVTierEnhancer;
 import common.recipeLoaders.AlloySmelter;
 import common.recipeLoaders.Assembler;
 import common.recipeLoaders.AssemblyLine;
@@ -35,8 +34,6 @@ public class Recipes {
 
     public static void postInit() {
         KekzCore.LOGGER.info("Registering recipes...");
-
-        LuVTierEnhancer.addToBlackListForOsmiridiumReplacement(new ItemStack(Blocks.lscLapotronicEnergyUnit, 1, 2));
 
         new AlloySmelter().run();
         new Assembler().run();


### PR DESCRIPTION
Remove luvtierenhancer references, so that these things can be removed in bartworks.

Should be merged together with the BW PR. (just this one would change a recipe, just the other would make it crash)

Only merge together with:
https://github.com/GTNewHorizons/bartworks/pull/320
https://github.com/GTNewHorizons/GT5-Unofficial/pull/1954