### PR TITLE
Add per fluid capacity to TFFT storage field tooltip

### DIFF
--- a/src/main/java/common/itemBlocks/IB_TFFTStorageField.java
+++ b/src/main/java/common/itemBlocks/IB_TFFTStorageField.java
@@ -14,6 +14,8 @@ import common.tileentities.GTMTE_TFFT;
 
 public class IB_TFFTStorageField extends ItemBlock {
 
+    private static final int UNIQUE_FLUIDS_PER_CELL = 25;
+
     public IB_TFFTStorageField(Block block) {
         super(block);
     }
@@ -47,7 +49,7 @@ public class IB_TFFTStorageField extends ItemBlock {
             lines.add(
                     "Per Fluid Capacity: " + EnumChatFormatting.BLUE
                             + NumberFormat.getNumberInstance()
-                                    .format(GTMTE_TFFT.Field.VALUES[meta - 1].getCapacity() / 25)
+                                    .format(GTMTE_TFFT.Field.VALUES[meta - 1].getCapacity() / UNIQUE_FLUIDS_PER_CELL)
                             + EnumChatFormatting.GRAY
                             + " L");
             lines.add(

--- a/src/main/java/common/itemBlocks/IB_TFFTStorageField.java
+++ b/src/main/java/common/itemBlocks/IB_TFFTStorageField.java
@@ -45,6 +45,12 @@ public class IB_TFFTStorageField extends ItemBlock {
                             + EnumChatFormatting.GRAY
                             + " L");
             lines.add(
+                    "Per Fluid Capacity: " + EnumChatFormatting.BLUE
+                            + NumberFormat.getNumberInstance()
+                                    .format(GTMTE_TFFT.Field.VALUES[meta - 1].getCapacity() / 25)
+                            + EnumChatFormatting.GRAY
+                            + " L");
+            lines.add(
                     "Power Draw: " + EnumChatFormatting.BLUE
                             + GTMTE_TFFT.Field.VALUES[meta - 1].getCost()
                             + EnumChatFormatting.GRAY


### PR DESCRIPTION
The TFFT's shtick is that it stores multiple fluids, thus I think it's logical that you can see how much you can store of each fluid per storage field on their tooltip.

![tfft](https://github.com/GTNewHorizons/KekzTech/assets/127234178/06d482f1-ff70-4214-a12a-3c72c6b6b7d9)
