### PR TITLE
Fix lsc capacitor check

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -600,7 +600,7 @@ public class GTMTE_LapotronicSuperCapacitor
         }
 
         // Check if enough (more than 50%) non-empty caps
-        if (capacitors[8] > capacitors[0] + capacitors[1]
+        if (capacitors[5] > capacitors[0] + capacitors[1]
                 + capacitors[2]
                 + capacitors[3]
                 + getUHVCapacitorCount()


### PR DESCRIPTION
LSC needs (more than 50%) non-empty caps. This check was broken and not checking anything at all.

caused by https://github.com/GTNewHorizons/KekzTech/commit/d5f9b910087e76530e787bebbe3ffcebc0cc8417
fixes https://discord.com/channels/181078474394566657/939305179524792340/1184924324524720238

tested with beta1 and seems to all work now.