### PR TITLE
Fix LSC wireless explosions

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -1013,7 +1013,11 @@ public class GTMTE_LapotronicSuperCapacitor
      */
     @Override
     public long maxEUInput() {
-        return mMaxEUIn;
+        if (wireless_mode) {
+            return Long.MAX_VALUE;
+        } else {
+            return mMaxEUIn;
+        }
     }
 
     @Override
@@ -1023,7 +1027,11 @@ public class GTMTE_LapotronicSuperCapacitor
 
     @Override
     public long maxEUOutput() {
-        return mMaxEUOut;
+        if (wireless_mode) {
+            return Long.MAX_VALUE;
+        } else {
+            return mMaxEUOut;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12620.

I tested it and I was easily able to get the explosions without this fix but no longer with it. (test setup: LSC with just 9 uhv caps and high tier glass filled by highest amp umv laser from debug power gen. Fill up a bit, then activate wireless.)

So it seems to work.