### PR TITLE
Fix missing LSC casing amount check

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -574,6 +574,8 @@ public class GTMTE_LapotronicSuperCapacitor extends
 
         if (!checkPiece(STRUCTURE_PIECE_BASE, 2, 1, 0)) return false;
 
+        if (casingAmount < 17) return false;
+
         topState = TopState.NotTop; // need at least one layer of capacitor to form, obviously
         int layer = 2;
         while (true) {


### PR DESCRIPTION
So it claims to limit the amount of LSC casings to at least 17x, however it has never really checked this since two years ago?






