### PR TITLE
Added a time to empty/time to full readout on the LSC

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -921,27 +921,27 @@ public class GTMTE_LapotronicSuperCapacitor extends
         ll.add("Passive Loss: " + nf.format(passiveDischargeAmount) + "EU/t");
         ll.add("EU IN: " + GT_Utility.formatNumbers(inputLastTick) + "EU/t");
         ll.add("EU OUT: " + GT_Utility.formatNumbers(outputLastTick) + "EU/t");
-        ll.add("Avg EU IN: " + nf.format(AvgIn) + " (last " + secInterval + " seconds)");
-        ll.add("Avg EU OUT: " + nf.format(AvgOut) + " (last " + secInterval + " seconds)");
+        ll.add("Avg EU IN: " + nf.format(avgIn) + " (last " + secInterval + " seconds)");
+        ll.add("Avg EU OUT: " + nf.format(avgOut) + " (last " + secInterval + " seconds)");
 
-    // Check if the system is charging or discharging
-    if (avgIn > avgOut) {
-    // Calculate time to full if charging
-    if (avgIn != 0) {
-            double timeToFull = (capacity.longValue() - stored.longValue()) / avgIn / 60;
-            ll.add("Time to Full: " + nf.format(timeToFull) + " minutes");
+        // Check if the system is charging or discharging
+        if (avgIn > avgOut) {
+            // Calculate time to full if charging
+            if (avgIn != 0) {
+                double timeToFull = (capacity.longValue() - stored.longValue()) / avgIn / 60;
+                ll.add("Time to Full: " + nf.format(timeToFull) + " minutes");
+            } else {
+                ll.add("Completely full");
+            }
         } else {
-            ll.add("Completely full");
+            // Calculate time to empty if discharging
+            if (avgOut != 0) {
+                double timeToEmpty = stored.longValue() / avgOut / 60;
+                ll.add("Time to Empty: " + nf.format(timeToEmpty) + " minutes");
+            } else {
+                ll.add("Completely empty");
+            }
         }
-    } else {
-        // Calculate time to empty if discharging
-        if (avgOut != 0) {
-            double timeToEmpty = stored.longValue() / avgOut / 60;
-            ll.add("Time to Empty: " + nf.format(timeToEmpty) + " minutes");
-        } else {
-            ll.add("Completely empty");
-        }
-    }
         ll.add(
                 "Maintenance Status: " + ((super.getRepairStatus() == super.getIdealStatus())
                         ? EnumChatFormatting.GREEN + "Working perfectly" + EnumChatFormatting.RESET

--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -902,6 +902,10 @@ public class GTMTE_LapotronicSuperCapacitor extends
         return sum / Math.max(energyOutputValues.size(), 1);
     }
 
+    // Caching avgin and avgout
+    double avgIn = getAvgIn();
+    double avgOut = getAvgOut();
+
     @Override
     public String[] getInfoData() {
         NumberFormat nf = NumberFormat.getNumberInstance();
@@ -917,12 +921,8 @@ public class GTMTE_LapotronicSuperCapacitor extends
         ll.add("Passive Loss: " + nf.format(passiveDischargeAmount) + "EU/t");
         ll.add("EU IN: " + GT_Utility.formatNumbers(inputLastTick) + "EU/t");
         ll.add("EU OUT: " + GT_Utility.formatNumbers(outputLastTick) + "EU/t");
-        ll.add("Avg EU IN: " + nf.format(getAvgIn()) + " (last " + secInterval + " seconds)");
-        ll.add("Avg EU OUT: " + nf.format(getAvgOut()) + " (last " + secInterval + " seconds)");
-
-    // Caching avgin and avgout
-    double avgIn = getAvgIn();
-    double avgOut = getAvgOut();
+        ll.add("Avg EU IN: " + nf.format(AvgIn) + " (last " + secInterval + " seconds)");
+        ll.add("Avg EU OUT: " + nf.format(AvgOut) + " (last " + secInterval + " seconds)");
 
     // Check if the system is charging or discharging
     if (avgIn > avgOut) {

--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -919,6 +919,18 @@ public class GTMTE_LapotronicSuperCapacitor extends
         ll.add("EU OUT: " + GT_Utility.formatNumbers(outputLastTick) + "EU/t");
         ll.add("Avg EU IN: " + nf.format(getAvgIn()) + " (last " + secInterval + " seconds)");
         ll.add("Avg EU OUT: " + nf.format(getAvgOut()) + " (last " + secInterval + " seconds)");
+
+        // Check if the system is charging or discharging
+        if (inputLastTick > outputLastTick) {
+            // Calculate time to full if charging
+            double timeToFull = (capacity.longValue() - stored.longValue()) / inputLastTick;
+            ll.add("Time to Full: " + nf.format(timeToFull) + " seconds");
+        } else {
+            // Calculate time to empty if discharging
+            double timeToEmpty = stored.longValue() / outputLastTick;
+            ll.add("Time to Empty: " + nf.format(timeToEmpty) + " seconds");
+        }
+
         ll.add(
                 "Maintenance Status: " + ((super.getRepairStatus() == super.getIdealStatus())
                         ? EnumChatFormatting.GREEN + "Working perfectly" + EnumChatFormatting.RESET

--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -902,14 +902,14 @@ public class GTMTE_LapotronicSuperCapacitor extends
         return sum / Math.max(energyOutputValues.size(), 1);
     }
 
-    // Caching avgin and avgout
-    double avgIn = getAvgIn();
-    double avgOut = getAvgOut();
-
     @Override
     public String[] getInfoData() {
         NumberFormat nf = NumberFormat.getNumberInstance();
         int secInterval = DURATION_AVERAGE_TICKS / 20;
+
+        // Caching avgin and avgout
+        double avgIn = getAvgIn();
+        double avgOut = getAvgOut();
 
         final ArrayList<String> ll = new ArrayList<>();
         ll.add(EnumChatFormatting.YELLOW + "Operational Data:" + EnumChatFormatting.RESET);

--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -920,25 +920,28 @@ public class GTMTE_LapotronicSuperCapacitor extends
         ll.add("Avg EU IN: " + nf.format(getAvgIn()) + " (last " + secInterval + " seconds)");
         ll.add("Avg EU OUT: " + nf.format(getAvgOut()) + " (last " + secInterval + " seconds)");
 
-        // Check if the system is charging or discharging
-        if (getAvgIn() > getAvgOut()) {
-            // Calculate time to full if charging
-            if (getAvgIn() != 0) {
-                double timeToFull = (capacity.longValue() - stored.longValue()) / getAvgIn() / 60;
-                ll.add("Time to Full: " + nf.format(timeToFull) + " minutes");
-            } else {
-                ll.add("Completely full");
-            }
-        } else {
-            // Calculate time to empty if discharging
-            if (getAvgOut() != 0) {
-                double timeToEmpty = stored.longValue() / getAvgOut() / 60;
-                ll.add("Time to Empty: " + nf.format(timeToEmpty) + " minutes");
-            } else {
-                ll.add("Completely empty");
-            }
-        }
+    // Caching avgin and avgout
+    double avgIn = getAvgIn();
+    double avgOut = getAvgOut();
 
+    // Check if the system is charging or discharging
+    if (avgIn > avgOut) {
+    // Calculate time to full if charging
+    if (avgIn != 0) {
+            double timeToFull = (capacity.longValue() - stored.longValue()) / avgIn / 60;
+            ll.add("Time to Full: " + nf.format(timeToFull) + " minutes");
+        } else {
+            ll.add("Completely full");
+        }
+    } else {
+        // Calculate time to empty if discharging
+        if (avgOut != 0) {
+            double timeToEmpty = stored.longValue() / avgOut / 60;
+            ll.add("Time to Empty: " + nf.format(timeToEmpty) + " minutes");
+        } else {
+            ll.add("Completely empty");
+        }
+    }
         ll.add(
                 "Maintenance Status: " + ((super.getRepairStatus() == super.getIdealStatus())
                         ? EnumChatFormatting.GREEN + "Working perfectly" + EnumChatFormatting.RESET

--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -921,14 +921,22 @@ public class GTMTE_LapotronicSuperCapacitor extends
         ll.add("Avg EU OUT: " + nf.format(getAvgOut()) + " (last " + secInterval + " seconds)");
 
         // Check if the system is charging or discharging
-        if (inputLastTick > outputLastTick) {
+        if (getAvgIn() > getAvgOut()) {
             // Calculate time to full if charging
-            double timeToFull = (capacity.longValue() - stored.longValue()) / inputLastTick;
-            ll.add("Time to Full: " + nf.format(timeToFull) + " seconds");
+            if (getAvgIn() != 0) {
+                double timeToFull = (capacity.longValue() - stored.longValue()) / getAvgIn() / 60;
+                ll.add("Time to Full: " + nf.format(timeToFull) + " minutes");
+            } else {
+                ll.add("Completely full");
+            }
         } else {
             // Calculate time to empty if discharging
-            double timeToEmpty = stored.longValue() / outputLastTick;
-            ll.add("Time to Empty: " + nf.format(timeToEmpty) + " seconds");
+            if (getAvgOut() != 0) {
+                double timeToEmpty = stored.longValue() / getAvgOut() / 60;
+                ll.add("Time to Empty: " + nf.format(timeToEmpty) + " minutes");
+            } else {
+                ll.add("Completely empty");
+            }
         }
 
         ll.add(


### PR DESCRIPTION
The readout displays the time to full or time to empty based on the average input and output of the eu into the lsc. The readout information is displayed in minutes as i felt it would be the easiest for the player to understand at a glance.


https://github.com/GTNewHorizons/KekzTech/assets/127531099/50e8dd43-01d3-4a71-b008-34a12eef834f

