### PR TITLE
Remove " (exact)" from LSC info readout.

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -912,10 +912,10 @@ public class GTMTE_LapotronicSuperCapacitor extends
 
         final ArrayList<String> ll = new ArrayList<>();
         ll.add(EnumChatFormatting.YELLOW + "Operational Data:" + EnumChatFormatting.RESET);
-        ll.add("EU Stored (exact): " + nf.format(stored) + "EU");
+        ll.add("EU Stored: " + nf.format(stored) + "EU");
         ll.add("EU Stored: " + toStandardForm(stored) + "EU");
         ll.add("Used Capacity: " + toPercentageFrom(stored, capacity));
-        ll.add("Total Capacity (exact): " + nf.format(capacity) + "EU");
+        ll.add("Total Capacity: " + nf.format(capacity) + "EU");
         ll.add("Total Capacity: " + toStandardForm(capacity) + "EU");
         ll.add("Passive Loss: " + nf.format(passiveDischargeAmount) + "EU/t");
         ll.add("EU IN: " + GT_Utility.formatNumbers(inputLastTick) + "EU/t");
@@ -967,8 +967,8 @@ public class GTMTE_LapotronicSuperCapacitor extends
                         + " Capacitors detected: "
                         + getUMVCapacitorCount());
         ll.add(
-                "Total wireless EU (exact): " + EnumChatFormatting.RED
-                        + GT_Utility.formatNumbers(WirelessNetworkManager.getUserEU(global_energy_user_uuid)));
+                "Total wireless EU: " + EnumChatFormatting.RED
+                        + nf.format(WirelessNetworkManager.getUserEU(global_energy_user_uuid)));
         ll.add(
                 "Total wireless EU: " + EnumChatFormatting.RED
                         + toStandardForm(WirelessNetworkManager.getUserEU(global_energy_user_uuid)));


### PR DESCRIPTION
This has been requested a few times on Discord already. This changes the label of the energy, capacity, and wireless energy from "Energy stored (exact): " to simply "Energy stored: ". The rationale for this is that a player will usually choose either the exact or the scientific format to display, and hide the other one. In this case, the text "exact" is superfluous.

New readouts, left is the full readout, right is an example of a condensed one with various lines hidden.

![](https://i.imgur.com/UyHH7dD.png)

Feel free to merge this whenever appropriate and/or delay as needed, this is not a critical change.