### PR TITLE
LSC info readout fixes.

### DIFF
--- a/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
+++ b/src/main/java/common/tileentities/GTMTE_LapotronicSuperCapacitor.java
@@ -912,14 +912,14 @@ public class GTMTE_LapotronicSuperCapacitor extends
 
         final ArrayList<String> ll = new ArrayList<>();
         ll.add(EnumChatFormatting.YELLOW + "Operational Data:" + EnumChatFormatting.RESET);
-        ll.add("EU Stored: " + nf.format(stored) + "EU");
-        ll.add("EU Stored: " + toStandardForm(stored) + "EU");
+        ll.add("EU Stored: " + nf.format(stored) + " EU");
+        ll.add("EU Stored: " + toStandardForm(stored) + " EU");
         ll.add("Used Capacity: " + toPercentageFrom(stored, capacity));
-        ll.add("Total Capacity: " + nf.format(capacity) + "EU");
-        ll.add("Total Capacity: " + toStandardForm(capacity) + "EU");
-        ll.add("Passive Loss: " + nf.format(passiveDischargeAmount) + "EU/t");
-        ll.add("EU IN: " + GT_Utility.formatNumbers(inputLastTick) + "EU/t");
-        ll.add("EU OUT: " + GT_Utility.formatNumbers(outputLastTick) + "EU/t");
+        ll.add("Total Capacity: " + nf.format(capacity) + " EU");
+        ll.add("Total Capacity: " + toStandardForm(capacity) + " EU");
+        ll.add("Passive Loss: " + nf.format(passiveDischargeAmount) + " EU/t");
+        ll.add("EU IN: " + GT_Utility.formatNumbers(inputLastTick) + " EU/t");
+        ll.add("EU OUT: " + GT_Utility.formatNumbers(outputLastTick) + " EU/t");
         ll.add("Avg EU IN: " + nf.format(avgIn) + " (last " + secInterval + " seconds)");
         ll.add("Avg EU OUT: " + nf.format(avgOut) + " (last " + secInterval + " seconds)");
 
@@ -968,12 +968,12 @@ public class GTMTE_LapotronicSuperCapacitor extends
                         + getUMVCapacitorCount());
         ll.add(
                 "Total wireless EU: " + EnumChatFormatting.RED
-                        + nf.format(WirelessNetworkManager.getUserEU(global_energy_user_uuid)));
+                        + nf.format(WirelessNetworkManager.getUserEU(global_energy_user_uuid))
+                        + " EU");
         ll.add(
                 "Total wireless EU: " + EnumChatFormatting.RED
-                        + toStandardForm(WirelessNetworkManager.getUserEU(global_energy_user_uuid)));
-
-        ll.add("---------------------------------------------");
+                        + toStandardForm(WirelessNetworkManager.getUserEU(global_energy_user_uuid))
+                        + " EU");
 
         final String[] a = new String[ll.size()];
         return ll.toArray(a);

--- a/src/main/java/util/Util.java
+++ b/src/main/java/util/Util.java
@@ -68,6 +68,9 @@ public class Util {
 
     /* If the number is less than 1, we round by the 6, otherwise to 2 */
     public static String toPercentageFrom(BigInteger value, BigInteger maxValue) {
+        if (BigInteger.ZERO.equals(maxValue)) {
+            return "0.00%";
+        }
         BigDecimal result = new BigDecimal(value).setScale(6, RoundingMode.HALF_UP)
                 .divide(new BigDecimal(maxValue), RoundingMode.HALF_UP);
         if (result.compareTo(Threshold_1) < 0) {


### PR DESCRIPTION
This PR contains two fixes:

* Fix DBZ error when the LSC capacity is zero (such as an unformed LSC). Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16167. *(A small philosophical question, what is the used capacity in this case, 0% or 100%? Right now I show 0%. No this does not matter at all for any practical purpose.)*
* Add a space between the value and the EU unit. [Picture](https://i.imgur.com/9rFyj1B.png). (This was originally intended as a part of https://github.com/GTNewHorizons/KekzTech/pull/88, but that one got merged before I managed to get it in.)